### PR TITLE
#41/feat/implement realm

### DIFF
--- a/MeaningOut/MeaningOut.xcodeproj/project.pbxproj
+++ b/MeaningOut/MeaningOut.xcodeproj/project.pbxproj
@@ -61,11 +61,13 @@
 		CE82DF5B2C219FAE00937DC7 /* RoundCornerButtonProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE82DF5A2C219FAE00937DC7 /* RoundCornerButtonProtocol.swift */; };
 		CE82DF5D2C21A41A00937DC7 /* ErrorTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE82DF5C2C21A41A00937DC7 /* ErrorTypes.swift */; };
 		CE82DF5F2C21A51900937DC7 /* CommunicatableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE82DF5E2C21A51900937DC7 /* CommunicatableViewController.swift */; };
-		CE82DFD82C297DF100937DC7 /* UIViewController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE82DFD72C297DF100937DC7 /* UIViewController+Extension.swift */; };
 		CE82DFAC2C27C1BF00937DC7 /* NaverAPIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE82DFAB2C27C1BF00937DC7 /* NaverAPIManager.swift */; };
 		CE82DFD42C29462700937DC7 /* MOImageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE82DFD32C29462700937DC7 /* MOImageManager.swift */; };
 		CE82DFD62C2970A600937DC7 /* NSObject+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE82DFD52C2970A600937DC7 /* NSObject+Extension.swift */; };
-
+		CE82DFD82C297DF100937DC7 /* UIViewController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE82DFD72C297DF100937DC7 /* UIViewController+Extension.swift */; };
+		CED1E0E82C36A238004BFBE1 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = CED1E0E72C36A238004BFBE1 /* RealmSwift */; };
+		CED1E0ED2C36A2EA004BFBE1 /* RealmRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E0EC2C36A2EA004BFBE1 /* RealmRepository.swift */; };
+		CED1E0EF2C36A6C8004BFBE1 /* LikedItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E0EE2C36A6C8004BFBE1 /* LikedItems.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -122,10 +124,12 @@
 		CE82DF5A2C219FAE00937DC7 /* RoundCornerButtonProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundCornerButtonProtocol.swift; sourceTree = "<group>"; };
 		CE82DF5C2C21A41A00937DC7 /* ErrorTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorTypes.swift; sourceTree = "<group>"; };
 		CE82DF5E2C21A51900937DC7 /* CommunicatableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunicatableViewController.swift; sourceTree = "<group>"; };
-		CE82DFD72C297DF100937DC7 /* UIViewController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Extension.swift"; sourceTree = "<group>"; };
 		CE82DFAB2C27C1BF00937DC7 /* NaverAPIManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NaverAPIManager.swift; sourceTree = "<group>"; };
 		CE82DFD32C29462700937DC7 /* MOImageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MOImageManager.swift; sourceTree = "<group>"; };
 		CE82DFD52C2970A600937DC7 /* NSObject+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSObject+Extension.swift"; sourceTree = "<group>"; };
+		CE82DFD72C297DF100937DC7 /* UIViewController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Extension.swift"; sourceTree = "<group>"; };
+		CED1E0EC2C36A2EA004BFBE1 /* RealmRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmRepository.swift; sourceTree = "<group>"; };
+		CED1E0EE2C36A6C8004BFBE1 /* LikedItems.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LikedItems.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -133,6 +137,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CED1E0E82C36A238004BFBE1 /* RealmSwift in Frameworks */,
 				CE0ECB172C1B159F0083E256 /* SnapKit in Frameworks */,
 				CE0ECB112C1B15900083E256 /* Kingfisher in Frameworks */,
 				CE0ECB142C1B15980083E256 /* Alamofire in Frameworks */,
@@ -297,6 +302,7 @@
 				CE0ECB7F2C1F48F00083E256 /* MOButtonLabelData.swift */,
 				CE0ECB832C1F601C0083E256 /* NaverShoppingResponse.swift */,
 				CE0ECBB62C2035C80083E256 /* UserData.swift */,
+				CED1E0EE2C36A6C8004BFBE1 /* LikedItems.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -339,6 +345,7 @@
 		CE61514B2C1AF69100165CAB /* MeaningOut */ = {
 			isa = PBXGroup;
 			children = (
+				CED1E0EB2C36A2DB004BFBE1 /* Repositories */,
 				CE82DFAA2C27C1B800937DC7 /* Manager */,
 				CE0ECB7E2C1F48E90083E256 /* Models */,
 				CE0ECB6D2C1EA9F90083E256 /* APIKeys */,
@@ -365,6 +372,14 @@
 			path = Manager;
 			sourceTree = "<group>";
 		};
+		CED1E0EB2C36A2DB004BFBE1 /* Repositories */ = {
+			isa = PBXGroup;
+			children = (
+				CED1E0EC2C36A2EA004BFBE1 /* RealmRepository.swift */,
+			);
+			path = Repositories;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -385,6 +400,7 @@
 				CE0ECB102C1B15900083E256 /* Kingfisher */,
 				CE0ECB132C1B15980083E256 /* Alamofire */,
 				CE0ECB162C1B159F0083E256 /* SnapKit */,
+				CED1E0E72C36A238004BFBE1 /* RealmSwift */,
 			);
 			productName = MeaningOut;
 			productReference = CE6151492C1AF69100165CAB /* MeaningOut.app */;
@@ -418,6 +434,7 @@
 				CE0ECB0F2C1B15900083E256 /* XCRemoteSwiftPackageReference "Kingfisher" */,
 				CE0ECB122C1B15980083E256 /* XCRemoteSwiftPackageReference "Alamofire" */,
 				CE0ECB152C1B159F0083E256 /* XCRemoteSwiftPackageReference "SnapKit" */,
+				CED1E0E62C36A238004BFBE1 /* XCRemoteSwiftPackageReference "realm-swift" */,
 			);
 			productRefGroup = CE61514A2C1AF69100165CAB /* Products */;
 			projectDirPath = "";
@@ -468,11 +485,13 @@
 				CE0ECB712C1EB6E10083E256 /* SearchResultCollectionViewCell.swift in Sources */,
 				CE0ECB6C2C1EA7840083E256 /* SearchResultViewController.swift in Sources */,
 				CE0ECBB52C2000B20083E256 /* SettingHeaderCell.swift in Sources */,
+				CED1E0ED2C36A2EA004BFBE1 /* RealmRepository.swift in Sources */,
 				CE0ECB842C1F601C0083E256 /* NaverShoppingResponse.swift in Sources */,
 				CE0ECB4B2C1D90FC0083E256 /* ProfileSettingViewController.swift in Sources */,
 				CE0ECB802C1F48F00083E256 /* MOButtonLabelData.swift in Sources */,
 				CE61514F2C1AF69100165CAB /* SceneDelegate.swift in Sources */,
 				CE0ECBB32C1FFF8F0083E256 /* SettingView.swift in Sources */,
+				CED1E0EF2C36A6C8004BFBE1 /* LikedItems.swift in Sources */,
 				CE0ECB4D2C1D91660083E256 /* ProfileImageView.swift in Sources */,
 				CE0ECBBC2C206D030083E256 /* UserDefaults+Extension.swift in Sources */,
 				CE0ECB692C1EA76C0083E256 /* SearchResultView.swift in Sources */,
@@ -758,6 +777,14 @@
 				minimumVersion = 5.7.1;
 			};
 		};
+		CED1E0E62C36A238004BFBE1 /* XCRemoteSwiftPackageReference "realm-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/realm/realm-swift.git";
+			requirement = {
+				kind = exactVersion;
+				version = 10.52.1;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -775,6 +802,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = CE0ECB152C1B159F0083E256 /* XCRemoteSwiftPackageReference "SnapKit" */;
 			productName = SnapKit;
+		};
+		CED1E0E72C36A238004BFBE1 /* RealmSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CED1E0E62C36A238004BFBE1 /* XCRemoteSwiftPackageReference "realm-swift" */;
+			productName = RealmSwift;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/MeaningOut/MeaningOut.xcodeproj/project.pbxproj
+++ b/MeaningOut/MeaningOut.xcodeproj/project.pbxproj
@@ -68,6 +68,8 @@
 		CED1E0E82C36A238004BFBE1 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = CED1E0E72C36A238004BFBE1 /* RealmSwift */; };
 		CED1E0ED2C36A2EA004BFBE1 /* RealmRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E0EC2C36A2EA004BFBE1 /* RealmRepository.swift */; };
 		CED1E0EF2C36A6C8004BFBE1 /* LikedItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E0EE2C36A6C8004BFBE1 /* LikedItems.swift */; };
+		CED1E1342C3AE776004BFBE1 /* LikedItemsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E1332C3AE776004BFBE1 /* LikedItemsViewController.swift */; };
+		CED1E1362C3AE77B004BFBE1 /* LikedItemsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED1E1352C3AE77B004BFBE1 /* LikedItemsView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -130,6 +132,8 @@
 		CE82DFD72C297DF100937DC7 /* UIViewController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Extension.swift"; sourceTree = "<group>"; };
 		CED1E0EC2C36A2EA004BFBE1 /* RealmRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmRepository.swift; sourceTree = "<group>"; };
 		CED1E0EE2C36A6C8004BFBE1 /* LikedItems.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LikedItems.swift; sourceTree = "<group>"; };
+		CED1E1332C3AE776004BFBE1 /* LikedItemsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LikedItemsViewController.swift; sourceTree = "<group>"; };
+		CED1E1352C3AE77B004BFBE1 /* LikedItemsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LikedItemsView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -184,6 +188,7 @@
 		CE0ECB332C1CA8ED0083E256 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				CED1E1322C3AE760004BFBE1 /* LikedItemsView */,
 				CE0ECBB82C2064C30083E256 /* TabBar */,
 				CE0ECBAF2C1FFF310083E256 /* Settings */,
 				CE0ECB722C1ECE5C0083E256 /* DetailSearch */,
@@ -380,6 +385,15 @@
 			path = Repositories;
 			sourceTree = "<group>";
 		};
+		CED1E1322C3AE760004BFBE1 /* LikedItemsView */ = {
+			isa = PBXGroup;
+			children = (
+				CED1E1332C3AE776004BFBE1 /* LikedItemsViewController.swift */,
+				CED1E1352C3AE77B004BFBE1 /* LikedItemsView.swift */,
+			);
+			path = LikedItemsView;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -475,8 +489,10 @@
 				CE0ECB7B2C1F369D0083E256 /* BaseViewActionTypes.swift in Sources */,
 				CE0ECBB72C2035C80083E256 /* UserData.swift in Sources */,
 				CE0ECB642C1DFCDD0083E256 /* ProfileSelectionViewCell.swift in Sources */,
+				CED1E1342C3AE776004BFBE1 /* LikedItemsViewController.swift in Sources */,
 				CE82DF5B2C219FAE00937DC7 /* RoundCornerButtonProtocol.swift in Sources */,
 				CE0ECB602C1DEAA40083E256 /* ProfileSelectionView.swift in Sources */,
+				CED1E1362C3AE77B004BFBE1 /* LikedItemsView.swift in Sources */,
 				CE0ECB3D2C1CB2940083E256 /* BaseViewControllerBuildable.swift in Sources */,
 				CE61514D2C1AF69100165CAB /* AppDelegate.swift in Sources */,
 				CE0ECB762C1ECE9F0083E256 /* DetailSearchView.swift in Sources */,

--- a/MeaningOut/MeaningOut/Models/LikedItems.swift
+++ b/MeaningOut/MeaningOut/Models/LikedItems.swift
@@ -1,0 +1,30 @@
+//
+//  LikedItems.swift
+//  MeaningOut
+//
+//  Created by user on 7/4/24.
+//
+import Foundation
+
+import RealmSwift
+
+final class LikedItems: Object {
+    @Persisted(primaryKey: true) var _id: ObjectId
+    @Persisted var title: String
+    @Persisted var mallName: String
+    @Persisted var lprice: String
+    @Persisted var link: String
+    @Persisted var productId: String
+    @Persisted var createdAt: Date = Date.now
+    //    @Persisted var image: Data -> id로 bundle에서 찾아 쓰기
+    
+    convenience init(title: String, mallName: String, lprice: String, link: String, productId: String) {
+        self.init()
+        
+        self.title = title
+        self.mallName = mallName
+        self.lprice = lprice
+        self.link = link
+        self.productId = productId
+    }
+}

--- a/MeaningOut/MeaningOut/Models/LikedItems.swift
+++ b/MeaningOut/MeaningOut/Models/LikedItems.swift
@@ -13,16 +13,18 @@ final class LikedItems: Object {
     @Persisted var mallName: String
     @Persisted var lprice: String
     @Persisted var link: String
+    @Persisted var image: String
     @Persisted(primaryKey: true) var productId: String
     @Persisted var createdAt: Date = Date.now
     //    @Persisted var image: Data -> id로 bundle에서 찾아 쓰기
     
-    convenience init(title: String, mallName: String, lprice: String, link: String, productId: String) {
+    convenience init(title: String, mallName: String, lprice: String, image: String ,link: String, productId: String) {
         self.init()
         
         self.title = title
         self.mallName = mallName
         self.lprice = lprice
+        self.image = image
         self.link = link
         self.productId = productId
     }

--- a/MeaningOut/MeaningOut/Models/LikedItems.swift
+++ b/MeaningOut/MeaningOut/Models/LikedItems.swift
@@ -9,12 +9,11 @@ import Foundation
 import RealmSwift
 
 final class LikedItems: Object {
-    @Persisted(primaryKey: true) var _id: ObjectId
     @Persisted var title: String
     @Persisted var mallName: String
     @Persisted var lprice: String
     @Persisted var link: String
-    @Persisted var productId: String
+    @Persisted(primaryKey: true) var productId: String
     @Persisted var createdAt: Date = Date.now
     //    @Persisted var image: Data -> id로 bundle에서 찾아 쓰기
     

--- a/MeaningOut/MeaningOut/Repositories/RealmRepository.swift
+++ b/MeaningOut/MeaningOut/Repositories/RealmRepository.swift
@@ -1,0 +1,35 @@
+//
+//  RealmRepository.swift
+//  MeaningOut
+//
+//  Created by user on 7/4/24.
+//
+
+import RealmSwift
+
+final class RealmRepository {
+    static let shared = RealmRepository()
+    private let realm = try! Realm() // 이 부분 에러 핸들링 안되나...
+    
+    internal func createItem<T: Object>(_ data: T) {
+        do {
+            try realm.write {
+                realm.add(data)
+            }
+        } catch {
+            print("Realm Create Error")
+        }
+    }
+    
+    internal func readAllItem<T: Object>(of: T.Type) -> Results<T> {
+        return realm.objects(T.self)
+    }
+    
+    internal func readItem<T: Object>(_ pk: ObjectId) -> T? {
+        return realm.object(ofType: T.self, forPrimaryKey: pk)
+    }
+    
+    internal func updateItem<T: Object>(from oldValue: T, to newValue: T) {
+        realm.create(T.self, value: newValue, update: .modified)
+    }
+}

--- a/MeaningOut/MeaningOut/Repositories/RealmRepository.swift
+++ b/MeaningOut/MeaningOut/Repositories/RealmRepository.swift
@@ -11,25 +11,37 @@ final class RealmRepository {
     static let shared = RealmRepository()
     private let realm = try! Realm() // 이 부분 에러 핸들링 안되나...
     
-    internal func createItem<T: Object>(_ data: T) {
+    internal func create<T: Object>(_ data: T) {
         do {
             try realm.write {
                 realm.add(data)
             }
         } catch {
             print("Realm Create Error")
+            print(error.localizedDescription)
         }
     }
     
-    internal func readAllItem<T: Object>(of: T.Type) -> Results<T> {
+    internal func readAll<T: Object>(of: T.Type) -> Results<T> {
         return realm.objects(T.self)
     }
     
-    internal func readItem<T: Object>(_ pk: ObjectId) -> T? {
-        return realm.object(ofType: T.self, forPrimaryKey: pk)
+    internal func read<T: Object>(_ data: Object) -> T? {
+        return realm.object(ofType: T.self, forPrimaryKey: data.objectSchema.primaryKeyProperty)
     }
     
-    internal func updateItem<T: Object>(from oldValue: T, to newValue: T) {
-        realm.create(T.self, value: newValue, update: .modified)
+    internal func readLikedItems<T: LikedItems>(_ data: T) -> T? {
+        return realm.object(ofType: T.self, forPrimaryKey: data.productId)
+    }
+    
+    internal func delete<T: Object>(_ data: T) {
+        do {
+            try realm.write {
+                realm.delete(data)
+            }
+        } catch {
+            print("Realm Delete Error")
+            print(error.localizedDescription)
+        }
     }
 }

--- a/MeaningOut/MeaningOut/Repositories/RealmRepository.swift
+++ b/MeaningOut/MeaningOut/Repositories/RealmRepository.swift
@@ -37,7 +37,8 @@ final class RealmRepository {
     internal func delete<T: Object>(_ data: T) {
         do {
             try realm.write {
-                realm.delete(data)
+//                realm.delete(data)
+                
             }
         } catch {
             print("Realm Delete Error")

--- a/MeaningOut/MeaningOut/Repositories/RealmRepository.swift
+++ b/MeaningOut/MeaningOut/Repositories/RealmRepository.swift
@@ -37,8 +37,7 @@ final class RealmRepository {
     internal func delete<T: Object>(_ data: T) {
         do {
             try realm.write {
-//                realm.delete(data)
-                
+                realm.delete(data)
             }
         } catch {
             print("Realm Delete Error")

--- a/MeaningOut/MeaningOut/Views/DetailSearch/DetailSearchViewController.swift
+++ b/MeaningOut/MeaningOut/Views/DetailSearch/DetailSearchViewController.swift
@@ -15,6 +15,8 @@ final class DetailSearchViewController: MOBaseViewController, CommunicatableBase
         }
     }
     
+    private var likedItems = RealmRepository.shared.readAll(of: LikedItems.self)
+    
     internal struct State: DetailSearchViewControllerState {
         var shoppingItem: ShoppingItem = ShoppingItem.dummyShoppingItem()
         var userData: UserData = UserData.dummyUserData()
@@ -84,18 +86,18 @@ final class DetailSearchViewController: MOBaseViewController, CommunicatableBase
     }
     
     private func addToLikedItems() {
-        if state.userData.likedItems.contains(where: {$0.productId == state.shoppingItem.productId}) == false {
-            state.userData.likedItems.append(state.shoppingItem)
-        }
+//        if state.userData.likedItems.contains(where: {$0.productId == state.shoppingItem.productId}) == false {
+//            state.userData.likedItems.append(state.shoppingItem)
+//        }
     }
     
     private func removeFromLikedItems() {
-        for i in 0..<state.userData.likedItems.count {
-            let likedItem = state.userData.likedItems[i]
-            if likedItem.productId == state.shoppingItem.productId {
-                state.userData.likedItems.remove(at: i)
-                return
-            }
-        }
+//        for i in 0..<state.userData.likedItems.count {
+//            let likedItem = state.userData.likedItems[i]
+//            if likedItem.productId == state.shoppingItem.productId {
+//                state.userData.likedItems.remove(at: i)
+//                return
+//            }
+//        }
     }
 }

--- a/MeaningOut/MeaningOut/Views/DetailSearch/DetailSearchViewController.swift
+++ b/MeaningOut/MeaningOut/Views/DetailSearch/DetailSearchViewController.swift
@@ -86,18 +86,31 @@ final class DetailSearchViewController: MOBaseViewController, CommunicatableBase
     }
     
     private func addToLikedItems() {
-//        if state.userData.likedItems.contains(where: {$0.productId == state.shoppingItem.productId}) == false {
-//            state.userData.likedItems.append(state.shoppingItem)
-//        }
+        let data = LikedItems(
+            title: state.shoppingItem.title,
+            mallName: state.shoppingItem.mallName,
+            lprice: state.shoppingItem.lprice,
+            image: state.shoppingItem.image,
+            link: state.shoppingItem.link,
+            productId: state.shoppingItem.productId
+        )
+        
+        if RealmRepository.shared.readLikedItems(data) != nil {
+            RealmRepository.shared.create(data)
+        }
     }
     
     private func removeFromLikedItems() {
-//        for i in 0..<state.userData.likedItems.count {
-//            let likedItem = state.userData.likedItems[i]
-//            if likedItem.productId == state.shoppingItem.productId {
-//                state.userData.likedItems.remove(at: i)
-//                return
-//            }
-//        }
+        let data = LikedItems(
+            title: state.shoppingItem.title,
+            mallName: state.shoppingItem.mallName,
+            lprice: state.shoppingItem.lprice,
+            image: state.shoppingItem.image,
+            link: state.shoppingItem.link,
+            productId: state.shoppingItem.productId
+        )
+        
+        
+        RealmRepository.shared.delete(data)
     }
 }

--- a/MeaningOut/MeaningOut/Views/LikedItemsView/LikedItemsView.swift
+++ b/MeaningOut/MeaningOut/Views/LikedItemsView/LikedItemsView.swift
@@ -1,0 +1,46 @@
+//
+//  LikedItemsView.swift
+//  MeaningOut
+//
+//  Created by user on 7/8/24.
+//
+
+import UIKit
+
+import SnapKit
+
+final class LikedItemsView: UIView {
+    let collectionView = UICollectionView(
+        frame: .zero,
+        collectionViewLayout: UICollectionView.createFlowLayout(
+            numberOfRowsInLine: 2,
+            spacing: 20
+        ))
+    
+    override init(frame: CGRect) {
+        super.init(frame: .zero)
+        
+        configureHierarchy()
+        configureLayout()
+        configureUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func configureHierarchy() {
+        self.addSubview(collectionView)
+    }
+    
+    func configureLayout() {
+        collectionView.snp.makeConstraints {
+            $0.edges.equalTo(self.safeAreaLayoutGuide)
+        }
+    }
+    
+    func configureUI() {
+        self.backgroundColor = MOColors.moWhite.color
+    }
+}
+

--- a/MeaningOut/MeaningOut/Views/LikedItemsView/LikedItemsViewController.swift
+++ b/MeaningOut/MeaningOut/Views/LikedItemsView/LikedItemsViewController.swift
@@ -21,6 +21,7 @@ final class LikedItemsViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        configureUI()
         configureDelegate()
     }
     
@@ -29,6 +30,10 @@ final class LikedItemsViewController: UIViewController {
         
         likedItems = RealmRepository.shared.readAll(of: LikedItems.self)
         baseView.collectionView.reloadData()
+    }
+    
+    func configureUI() {
+        navigationItem.title = "좋아요 누른 목록"
     }
     
     func configureDelegate() {

--- a/MeaningOut/MeaningOut/Views/LikedItemsView/LikedItemsViewController.swift
+++ b/MeaningOut/MeaningOut/Views/LikedItemsView/LikedItemsViewController.swift
@@ -1,0 +1,92 @@
+//
+//  LikedItemsViewController.swift
+//  MeaningOut
+//
+//  Created by user on 7/8/24.
+//
+
+import UIKit
+
+import RealmSwift
+
+final class LikedItemsViewController: UIViewController {
+    
+    private var likedItems = RealmRepository.shared.readAll(of: LikedItems.self)
+    private var baseView = LikedItemsView()
+    
+    override func loadView() {
+        self.view = baseView
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        configureDelegate()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        likedItems = RealmRepository.shared.readAll(of: LikedItems.self)
+        baseView.collectionView.reloadData()
+    }
+    
+    func configureDelegate() {
+        baseView.collectionView.delegate = self
+        baseView.collectionView.dataSource = self
+        baseView.collectionView.register(
+            SearchResultCollectionViewCell.self,
+            forCellWithReuseIdentifier: SearchResultCollectionViewCell.identifier
+        )
+    }
+    
+    @objc
+    func likedButtonTapped(_ sender: UIButton) {
+        print(#function)
+        let index = sender.tag
+        
+        let target = likedItems[index]
+        
+        RealmRepository.shared.delete(target)
+        
+        baseView.collectionView.reloadData()
+    }
+}
+extension LikedItemsViewController: UICollectionViewDelegate, UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return likedItems.count
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SearchResultCollectionViewCell.identifier, for: indexPath) as? SearchResultCollectionViewCell else { return UICollectionViewCell() }
+        cell.likeButton.tag = indexPath.row
+        
+        let data = likedItems[indexPath.row]
+        
+        do {
+            try MOImageManager.shared.fetchImage(
+                objectName: getTypeName(),
+                urlString: data.image
+            ) { image in
+                cell.setImage(with: image)
+            }
+        } catch NetworkError.urlNotGenerated {
+            print("Check Image URL")
+        } catch {
+            print(error.localizedDescription)
+        }
+        
+        cell.likeButton.addTarget(
+            self,
+            action: #selector(likedButtonTapped),
+            for: .touchUpInside
+        )
+        
+        cell.configureRealmData(data)
+        
+        cell.toggleIsLiked()
+        cell.setAsLikeItem()
+        
+        return cell
+    }
+}

--- a/MeaningOut/MeaningOut/Views/SearchResult/SearchResultCollectionViewCell.swift
+++ b/MeaningOut/MeaningOut/Views/SearchResult/SearchResultCollectionViewCell.swift
@@ -12,7 +12,7 @@ import SnapKit
 
 final class SearchResultCollectionViewCell: UICollectionViewCell, BaseViewBuildable {
     private let itemImage = UIImageView()
-    private let likeButton = RoundCornerButton(
+    private(set) var likeButton = RoundCornerButton(
         type: .image,
         image: UIImage(named: ImageName.unSelecteLikeButtonImage),
         color: MOColors.moGray100.color.withAlphaComponent(0.3)
@@ -133,6 +133,26 @@ final class SearchResultCollectionViewCell: UICollectionViewCell, BaseViewBuilda
             isLiked = false
         }
     }
+        
+        
+        internal func configureRealmData(_ data: LikedItems) {
+            
+            mallName.text = data.mallName
+            
+            title.text = data.title.replacingOccurrences(
+                of: ReplaceStringConstants.boldHTMLOpenTag,
+                with: String.emptyString
+            ).replacingOccurrences(
+                of: ReplaceStringConstants.boldHTMLCloseTag,
+                with: String.emptyString
+            )
+            
+            let formattedPrice = Int(data.lprice)?.formatted() ?? SearchResultConstants.defaultPrice
+            price.text = formattedPrice + SearchResultConstants.won
+            
+            isLiked = false
+        }
+    
     
     internal func setImage(with image: UIImage) {
         self.itemImage.image = image

--- a/MeaningOut/MeaningOut/Views/SearchResult/SearchResultView.swift
+++ b/MeaningOut/MeaningOut/Views/SearchResult/SearchResultView.swift
@@ -41,7 +41,7 @@ final class SearchResultView: UIView, BaseViewBuildable {
     private lazy var horizontalButtonStack = UIStackView(arrangedSubviews: buttons)
     private lazy var resultCollectionView = UICollectionView(
         frame: .zero,
-        collectionViewLayout: createFlowLayout(
+        collectionViewLayout: UICollectionView.createFlowLayout(
             numberOfRowsInLine: 2,
             spacing: 20
         )
@@ -214,8 +214,8 @@ final class SearchResultView: UIView, BaseViewBuildable {
     }
 }
 
-extension SearchResultView: UICollectionViewDelegate, UICollectionViewDataSource {
-    private func createFlowLayout(numberOfRowsInLine: CGFloat, spacing: CGFloat) -> UICollectionViewFlowLayout {
+extension UICollectionView {
+    static func createFlowLayout(numberOfRowsInLine: CGFloat, spacing: CGFloat) -> UICollectionViewFlowLayout {
         let flowLayout = UICollectionViewFlowLayout()
         flowLayout.scrollDirection = .vertical
         flowLayout.minimumLineSpacing = spacing
@@ -237,6 +237,9 @@ extension SearchResultView: UICollectionViewDelegate, UICollectionViewDataSource
         
         return flowLayout
     }
+}
+
+extension SearchResultView: UICollectionViewDelegate, UICollectionViewDataSource {
     
     internal func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return searchResult.items.count
@@ -269,6 +272,7 @@ extension SearchResultView: UICollectionViewDelegate, UICollectionViewDataSource
             title: data.title,
             mallName: data.mallName,
             lprice: data.lprice,
+            image: data.image,
             link: data.link,
             productId: data.productId
         )

--- a/MeaningOut/MeaningOut/Views/SearchResult/SearchResultView.swift
+++ b/MeaningOut/MeaningOut/Views/SearchResult/SearchResultView.swift
@@ -265,11 +265,6 @@ extension SearchResultView: UICollectionViewDelegate, UICollectionViewDataSource
         
         cell.configureData(data)
         
-//        if userData.likedItems.contains(where: { $0.productId == data.productId }) {
-//            cell.toggleIsLiked()
-//            cell.setAsLikeItem()
-//        }
-        
         let likedItem = LikedItems(
             title: data.title,
             mallName: data.mallName,
@@ -298,8 +293,6 @@ extension SearchResultView: UICollectionViewDelegate, UICollectionViewDataSource
 extension SearchResultView: UICollectionViewDataSourcePrefetching {
     internal func collectionView(_ collectionView: UICollectionView, prefetchItemsAt indexPaths: [IndexPath]) {
         if let lastItem = indexPaths.last {
-//            print(#function, lastItem.row, searchResult.items.count)
-//            print(searchResult.items.count)
             if lastItem.row >= searchResult.items.count - 4 {
                 delegate?.baseViewAction(.searchResultViewAction(.prefetchItems))
             }

--- a/MeaningOut/MeaningOut/Views/SearchResult/SearchResultView.swift
+++ b/MeaningOut/MeaningOut/Views/SearchResult/SearchResultView.swift
@@ -14,6 +14,7 @@ final class SearchResultView: UIView, BaseViewBuildable {
     private let sortOptions: [SortOptions] = SortOptions.allCases
     private var selectedButton = SortOptions.simularity
     private var imageCache: [String : UIImage] = [:]
+    private var likedItems = RealmRepository.shared.readAll(of: LikedItems.self)
     
     private let simularityFilterButton = RoundCornerButton(
         type: .sort(.simularity),
@@ -263,7 +264,21 @@ extension SearchResultView: UICollectionViewDelegate, UICollectionViewDataSource
         }
         
         cell.configureData(data)
-        if userData.likedItems.contains(where: { $0.productId == data.productId }) {
+        
+//        if userData.likedItems.contains(where: { $0.productId == data.productId }) {
+//            cell.toggleIsLiked()
+//            cell.setAsLikeItem()
+//        }
+        
+        let likedItem = LikedItems(
+            title: data.title,
+            mallName: data.mallName,
+            lprice: data.lprice,
+            link: data.link,
+            productId: data.productId
+        )
+        
+        if RealmRepository.shared.readLikedItems(likedItem) != nil {
             cell.toggleIsLiked()
             cell.setAsLikeItem()
         }

--- a/MeaningOut/MeaningOut/Views/SearchResult/SearchResultViewController.swift
+++ b/MeaningOut/MeaningOut/Views/SearchResult/SearchResultViewController.swift
@@ -145,7 +145,7 @@ extension SearchResultViewController: BaseViewDelegate {
         let data = LikedItems(
             title: shoppingItem.title,
             mallName: shoppingItem.mallName,
-            lprice: shoppingItem.lprice,
+            lprice: shoppingItem.lprice, image: shoppingItem.image,
             link: shoppingItem.link,
             productId: shoppingItem.productId
         )
@@ -160,6 +160,7 @@ extension SearchResultViewController: BaseViewDelegate {
             title: shoppingItem.title,
             mallName: shoppingItem.mallName,
             lprice: shoppingItem.lprice,
+            image: shoppingItem.image,
             link: shoppingItem.link,
             productId: shoppingItem.productId
         )

--- a/MeaningOut/MeaningOut/Views/SearchResult/SearchResultViewController.swift
+++ b/MeaningOut/MeaningOut/Views/SearchResult/SearchResultViewController.swift
@@ -164,7 +164,10 @@ extension SearchResultViewController: BaseViewDelegate {
             productId: shoppingItem.productId
         )
         
-        RealmRepository.shared.delete(data)
+        if let likedItem = RealmRepository.shared.readLikedItems(data) {
+            
+            RealmRepository.shared.delete(likedItem)
+        }
     }
     
     private func syncData() {

--- a/MeaningOut/MeaningOut/Views/SearchResult/SearchResultViewController.swift
+++ b/MeaningOut/MeaningOut/Views/SearchResult/SearchResultViewController.swift
@@ -142,21 +142,29 @@ extension SearchResultViewController: BaseViewDelegate {
     }
     
     private func addToLikedItems(_ shoppingItem: ShoppingItem) {
-        if state.userData.likedItems.contains(where: { $0.productId == shoppingItem.productId }) == false {
-            state.userData.likedItems.append(shoppingItem)
-            syncData()
+        let data = LikedItems(
+            title: shoppingItem.title,
+            mallName: shoppingItem.mallName,
+            lprice: shoppingItem.lprice,
+            link: shoppingItem.link,
+            productId: shoppingItem.productId
+        )
+        
+        if RealmRepository.shared.readLikedItems(data) == nil {
+            RealmRepository.shared.create(data)
         }
     }
     
     private func removeFromLikedItems(_ shoppingItem: ShoppingItem) {
-        for i in 0..<state.userData.likedItems.count {
-            let likedItem = state.userData.likedItems[i]
-            if likedItem.productId == shoppingItem.productId {
-                state.userData.likedItems.remove(at: i)
-                syncData()
-                return
-            }
-        }
+        let data = LikedItems(
+            title: shoppingItem.title,
+            mallName: shoppingItem.mallName,
+            lprice: shoppingItem.lprice,
+            link: shoppingItem.link,
+            productId: shoppingItem.productId
+        )
+        
+        RealmRepository.shared.delete(data)
     }
     
     private func syncData() {

--- a/MeaningOut/MeaningOut/Views/SearchResult/SearchResultViewController.swift
+++ b/MeaningOut/MeaningOut/Views/SearchResult/SearchResultViewController.swift
@@ -165,8 +165,7 @@ extension SearchResultViewController: BaseViewDelegate {
         )
         
         if let likedItem = RealmRepository.shared.readLikedItems(data) {
-            
-            RealmRepository.shared.delete(likedItem)
+            RealmRepository.shared.delete(likedItem) // 생성한 data 말고, realm에서 꺼내온값만 다시 넣어서 삭제할 수 있음
         }
     }
     

--- a/MeaningOut/MeaningOut/Views/TabBar/TabBarController.swift
+++ b/MeaningOut/MeaningOut/Views/TabBar/TabBarController.swift
@@ -34,6 +34,7 @@ final class TabBarController: UITabBarController {
         let likedItemsViewController = LikedItemsViewController()
         likedItemsViewController.tabBarItem.image = UIImage(systemName: "heart")
         likedItemsViewController.tabBarItem.title = "좋아요"
+        let likedItemsViewNavigationController = UINavigationController(rootViewController: likedItemsViewController)
         
         let settingViewController = SettingViewController(SettingView())
         let settingViewNavigationController = UINavigationController(rootViewController: settingViewController)
@@ -41,10 +42,10 @@ final class TabBarController: UITabBarController {
         settingViewController.tabBarItem.image = UIImage(systemName: TabBarItemProperty.settingView.systemName)
         settingViewController.tabBarItem.title = TabBarItemProperty.settingView.title
         
-        setViewControllers(
-            [mainViewNavigationController,
-             likedItemsViewController,
-             settingViewNavigationController],
+        setViewControllers([
+            mainViewNavigationController,
+            likedItemsViewNavigationController,
+            settingViewNavigationController],
             animated: true
         )
         

--- a/MeaningOut/MeaningOut/Views/TabBar/TabBarController.swift
+++ b/MeaningOut/MeaningOut/Views/TabBar/TabBarController.swift
@@ -31,6 +31,10 @@ final class TabBarController: UITabBarController {
         mainViewNavigationController.tabBarItem.image = UIImage(systemName: TabBarItemProperty.mainView.systemName)
         mainViewNavigationController.tabBarItem.title = TabBarItemProperty.mainView.title
         
+        let likedItemsViewController = LikedItemsViewController()
+        likedItemsViewController.tabBarItem.image = UIImage(systemName: "heart")
+        likedItemsViewController.tabBarItem.title = "좋아요"
+        
         let settingViewController = SettingViewController(SettingView())
         let settingViewNavigationController = UINavigationController(rootViewController: settingViewController)
         settingViewNavigationController.removeBackBarButtonTitle()
@@ -38,7 +42,9 @@ final class TabBarController: UITabBarController {
         settingViewController.tabBarItem.title = TabBarItemProperty.settingView.title
         
         setViewControllers(
-            [mainViewNavigationController, settingViewNavigationController],
+            [mainViewNavigationController,
+             likedItemsViewController,
+             settingViewNavigationController],
             animated: true
         )
         


### PR DESCRIPTION
## 개요 및 관련 이슈
- Realm을 이용한 좋아요 기능을 구현합니다.

| ⚒️ Title | Realm을 이용한 좋아요 기능을 구현합니다. | 
| :--- | :--- |
| 📜 **Description** | 좋아요를 누른 아이템들을 realm으로 저장하여 좋아요 탭에서 보여줍니다 |
| 📌 **Issue Number** | #41  |
| 좋아요 탭 구현 | ![Simulator Screen Recording - iPhone 15 Pro - 2024-07-08 at 03 34 36](https://github.com/alpaka99/MeaningOut-Project/assets/22471820/6da5b095-0c11-4d54-883e-de90a6edc9bc)|


---

## 작업 결과
- UserDefault에 UserData 모델에서 저장하던 shoppingItem을 Realm에서 LikedItems라는 모델로 저장하는것으로 변경하였습니다.
- 이 과정중에서, Realm에 delete할 수 있는 데이터는 realm에서 직접 꺼낸 데이터 뿐이라는것을 꽤 오랜시간이 걸려서 깨달았습니다. 따라서 delete 메서드를 할때는 read를 한번 한 후에, delete을 하는것으로 변경하였습니다.
- 저장된 좋아요를 모두 볼 수 있는 LikedItemsViewController를 생성하였습니다. 이 뷰컨트롤러는 새로운 탭인 좋아요 탭에서 볼 수 있도록 하였습니다.
- 좋아요 탭인 LikedItemsViewController와 검색을 했을때 보이는 SearchResultViewController가 서로 좋아요를 누르거나 좋아요 취소를 누르는 행동이 서로 연동이 되도록 하였습니다.

#### 기타 공유사항
- 사용하지 않는 UserDefaults 데이터 삭제 및 UserDefaults migration을 생각해볼 수 있겠습니다. 
- RealmRepository의 개선여지가 있습니다. 아직 전부 다 generic하게 동작하지 않기 때문에 이 부분의 로직을 생각해볼 수 있겠습니다.